### PR TITLE
allow for debug mode (for development testing purposes)

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,17 +1,23 @@
-var DEFAULTS = {};
+'use strict';
 
-DEFAULTS.HOST = 'api.vhx.tv';
-DEFAULTS.PROTOCOL = 'https://';
-DEFAULTS.API_VERSION = null;
-DEFAULTS.TIMEOUT = require('http').createServer().timeout;
-DEFAULTS.PACKAGE_VERSION = require('../package.json').version;
+var defaults = function(debug) {
+  var DEFAULTS = {};
 
-DEFAULTS.USER_AGENT = {
-  bindings_version: DEFAULTS.PACKAGE_VERSION,
-  lang: 'node',
-  lang_version: process.version,
-  platform: process.platform,
-  publisher: 'VHX'
+  DEFAULTS.HOST = debug ? 'api.crystal.dev' : 'api.vhx.tv';
+  DEFAULTS.PROTOCOL = debug ? 'http://' : 'https://';
+  DEFAULTS.API_VERSION = null;
+  DEFAULTS.TIMEOUT = require('http').createServer().timeout;
+  DEFAULTS.PACKAGE_VERSION = require('../package.json').version;
+
+  DEFAULTS.USER_AGENT = {
+    bindings_version: DEFAULTS.PACKAGE_VERSION,
+    lang: 'node',
+    lang_version: process.version,
+    platform: process.platform,
+    publisher: 'VHX'
+  };
+
+  return DEFAULTS;
 };
 
-module.exports = DEFAULTS;
+module.exports = defaults;

--- a/lib/vhx.js
+++ b/lib/vhx.js
@@ -9,13 +9,13 @@ var resources = {
   analytics:      require('./resources/analytics')
 };
 
-function VHX(key, version) {
+function VHX(key, debug) {
   var _this     = this,
-      defaults  = require('./defaults'),
+      defaults  = require('./defaults')(debug || false),
       pjson     = require('../package.json');
 
   if (!(_this instanceof VHX)) {
-    return new VHX(key, version);
+    return new VHX(key, debug);
   }
 
   _this._api = {


### PR DESCRIPTION
This PR adds a debug parameter to the VHX constructor. In this way if true is passed, the URL host and protocol will be a `.dev` url for vhx internal use for testing/development.