### PR TITLE
Feature/add headers

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -29,79 +29,81 @@ Resource.prototype = {
 
       params.http_method = _this.getHTTPMethod(params.method);
 
-      if (params.method.match(/retrieve|update|listItems|items|listFiles|files|addProduct|removeProduct|addItem|removeItem/)) {
-        _this[params.method] = function() {
-          params.args = arguments;
-          return new _this.buildMethodWithThreeArgs(params);
-        };
-      }
-      else {
-        _this[params.method] = function() {
-          params.args = arguments;
-          return new _this.buildMethodWithTwoArgs(params);
-        };
-      }
+      _this[params.method] = function() {
+        params.args = arguments;
+        return new _this.buildMethod(params);
+      };
     });
   },
 
+  buildMethod: function(params) {
+    var options = {
+      http_method: params.http_method,
+      client_method: params.method
+    };
+    var i;
+    var keyMap = {
+      callback: null,
+      id: null,
+      options: null
+    };
 
-    buildMethodWithTwoArgs: function(params) {
-      var options = {
-        http_method: params.http_method,
-        client_method: params.method
-      };
-
-      if (options.http_method === 'del') {
-        options.id = params.args[0];
-      } else {
-        options.options = params.args[0];
-      }
-
-      if (params.parentResource) {
-        options.parentResource = params.parentResource;
-      }
-      if (params.scope) {
-        options.scope = params.scope;
-      }
-
-      options.callback = params.args[1];
-
-      return params.resource.makeRequest.call(params.resource, options);
-    },
-
-    buildMethodWithThreeArgs: function(params) {
-      var options = {
-        http_method: params.http_method,
-        client_method: params.method
-      };
-
-      if (params.args[0][params.type]) {
-       if (params.resource.isCallbackFunction.call(params.resource, params.args[1])) {
-         options.callback = params.args[1];
-       }
-        options.id = params.resource.parseHref.call(params.resource, params.args[0][params.type]);
-        delete params.args[0][params.type];
-        options.options = params.args[0];
-      }
-      else {
-        options.id = params.resource.parseHref.call(params.resource, params.args[0]);
-        if (params.resource.isCallbackFunction.call(params.resource, params.args[1])) {
-          options.callback = params.args[1];
-        } else {
-          options.options = params.args[1];
-          options.callback = params.args[2];
+    for (i = 0; i < params.args.length; i++) {
+      // assign ID/HREF
+      if (i === 0) {
+        // if the first parameter is a string, it's the id/href
+        if (typeof(params.args[0]) === 'string' || typeof(params.args[0]) === 'number') {
+          options.id = params.resource.parseHref.call(params.resource, params.args[0]);
+          keyMap.id = 0;
+        }
+        else if (params.resource.isObject(params.args[0]) && params.args[0][params.type]) {
+          options.id = params.resource.parseHref.call(params.resource, params.args[0][params.type]);
+          delete params.args[0][params.type];
         }
       }
 
-      if (params.parentResource) {
-        options.parentResource = params.parentResource;
-      }
-      if (params.scope) {
-        options.scope = params.scope;
+      // if the parameter is a callback function
+      if (params.resource.isCallbackFunction.call(params.resource, params.args[i])) {
+        options.callback = params.args[i];
+        keyMap.callback = i;
       }
 
-      return params.resource.makeRequest.call(params.resource, options);
-    },
+      // assign request/parameters
+      if (i === 0 || i === 1 &&
+          params.method.match(/create|update|listItems|items|listFiles|files|addProduct|removeProduct|addItem|removeItem/)) {
+        // if the first or second parameter is an object, and is not the callback it is a request parameters
+        if (keyMap.options === null && keyMap.callback !== i && keyMap.id !== i && params.resource.isObject(params.args[i])) {
+          options.options = params.args[i];
+          keyMap.options = i;
+        }
+      }
+    }
+
+    // assign Headers
+    if (keyMap.callback) {
+      keyMap.headers = keyMap.callback - 1;
+    } else {
+      keyMap.headers = params.args.length;
+    }
+
+    if (keyMap.headers !== keyMap.options &&
+        keyMap.headers !== keyMap.callback &&
+        keyMap.headers !== keyMap.id &&
+        params.resource.isObject(params.args[keyMap.headers])) {
+        options.headers = params.args[keyMap.headers];
+    } else {
+      keyMap.headers = null;
+    }
+
+    if (params.parentResource) {
+      options.parentResource = params.parentResource;
+    }
+    if (params.scope) {
+      options.scope = params.scope;
+    }
+
+    return params.resource.makeRequest.call(params.resource, options);
+  },
 
   getHTTPMethod: function(method) {
     if (method === 'create') {
@@ -157,7 +159,7 @@ Resource.prototype = {
     }
   },
 
-  getParams: function(client_method, id, options, scope, parentResource) {
+  getParams: function(client_method, id, options, scope, parentResource, headers) {
     var _this = this,
         params = {};
 
@@ -193,7 +195,7 @@ Resource.prototype = {
 
   makeRequest: function(args) {
     var _this = this,
-        params = _this.getParams(args.client_method, args.id || null, args.options, args.scope || null, args.parentResource || null);
+        params = _this.getParams(args.client_method, args.id || null, args.options, args.scope || null, args.parentResource || null, args.headers || null);
 
     if (_this.isCallbackFunction(args.options)) {
       args.callback = args.options;

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -19,7 +19,7 @@ describe('Analytics', function() {
         type: 'income_statement',
         from: '2016-10-01',
         to: 'today'
-      }, function(err, report) {
+      }, { 'VHX-X-Header': 'foo' }, function(err, report) {
         expect(report).to.be.a('object');
         expect(report).to.be.property('_links');
         expect(report).to.be.property('data');
@@ -64,7 +64,7 @@ describe('Analytics', function() {
         from: '2016-07-19',
         to: '2016-07-20',
         by: 'day'
-      }, function(err, report) {
+      }, { 'VHX-X-Header': 'foo' }, function(err, report) {
         expect(report).to.be.a('object');
         expect(report).to.be.property('_links');
         expect(report).to.be.property('data');
@@ -95,7 +95,7 @@ describe('Analytics', function() {
         from: '2016-07-19',
         to: '2016-07-20',
         by: 'day'
-      }, function(err, report) {
+      }, { 'VHX-X-Header': 'foo' }, function(err, report) {
         expect(report).to.be.a('object');
         expect(report).to.be.property('_links');
         expect(report).to.be.property('data');
@@ -126,7 +126,7 @@ describe('Analytics', function() {
         from: '2016-07-20',
         to: '2016-08-20',
         by: 'month'
-      }, function(err, report) {
+      }, { 'VHX-X-Header': 'foo' }, function(err, report) {
         expect(report).to.be.a('object');
         expect(report).to.be.property('_links');
         expect(report).to.be.property('data');

--- a/test/collections.js
+++ b/test/collections.js
@@ -15,7 +15,7 @@ describe('Collections', function() {
 
   describe('List all collections', function() {
     it('it should GET all collections', function(done) {
-      vhx.collections.all({}, function(err, collections) {
+      vhx.collections.all({}, { 'VHX-X-Header': 'foo' }, function(err, collections) {
         expect(collections).to.be.a('object');
         expect(collections).to.be.property('_links');
         expect(collections).to.be.property('_embedded');
@@ -52,7 +52,7 @@ describe('Collections', function() {
   describe('Update a collection', function() {
     it('it should update a collection', function(done) {
 
-      vhx.collections.update(params.collection(), { description: params.description }, function(err, updatedCollection) {
+      vhx.collections.update(params.collection(), { description: params.description }, { 'VHX-X-Header': 'foo' }, function(err, updatedCollection) {
         expect(updatedCollection).to.be.a('object');
         expect(updatedCollection).to.be.property('_links');
         expect(updatedCollection).to.be.property('_embedded');

--- a/test/customers.js
+++ b/test/customers.js
@@ -24,11 +24,32 @@ describe('Customers', function() {
         done();
       });
     });
+    it('it should GET all customers with a header', function(done) {
+      vhx.customers.all({}, { 'VHX-X-Header': 'foo' }, function(err, customers) {
+        expect(customers).to.be.a('object');
+        expect(customers).to.be.property('_links');
+        expect(customers).to.be.property('_embedded');
+        expect(customers).to.be.property('count');
+        expect(customers._embedded).to.be.property('customers');
+        done();
+      });
+    });
   });
 
   describe('Retrieve a customer', function() {
       it('it should GET a single customer', function(done) {
         vhx.customers.retrieve(params.customer(), function(err, customer) {
+          expect(customer).to.be.a('object');
+          expect(customer).to.be.property('_links');
+          expect(customer).to.be.property('_embedded');
+          expect(customer).to.be.property('email');
+          expect(customer).to.be.property('name');
+          expect(customer._embedded).to.be.property('products');
+          done();
+        });
+      });
+      it('it should GET a single customer with a header', function(done) {
+        vhx.customers.retrieve(params.customer(), { 'VHX-X-Header': 'foo' }, function(err, customer) {
           expect(customer).to.be.a('object');
           expect(customer).to.be.property('_links');
           expect(customer).to.be.property('_embedded');
@@ -44,12 +65,27 @@ describe('Customers', function() {
     it('it should create a customer', function(done) {
       var email = params.email();
       var name = params.name();
+
       vhx.customers.create({ name: name, email: email }, function(err, customer) {
         expect(customer).to.be.a('object');
         expect(customer).to.be.property('_links');
         expect(customer).to.be.property('_embedded');
         expect(customer.name).to.equal(name);
         expect(customer.email).to.equal(email);
+        done();
+      });
+    });
+
+    it('it should create a customer with a header', function(done) {
+      var emailWithHeader = params.email();
+      var nameWithHeader = params.name();
+
+      vhx.customers.create({ name: nameWithHeader, email: emailWithHeader }, { 'VHX-X-Header': 'foo' }, function(err, customer) {
+        expect(customer).to.be.a('object');
+        expect(customer).to.be.property('_links');
+        expect(customer).to.be.property('_embedded');
+        expect(customer.name).to.equal(nameWithHeader);
+        expect(customer.email).to.equal(emailWithHeader);
         done();
       });
     });
@@ -66,10 +102,21 @@ describe('Customers', function() {
         done();
       });
     });
+
+    it('it should update a customer with a header', function(done) {
+      var name = params.name();
+      vhx.customers.update(params.customer(), { name: name }, { 'VHX-X-Header': 'foo' }, function(err, updatedCustomer) {
+        expect(updatedCustomer).to.be.a('object');
+        expect(updatedCustomer).to.be.property('_links');
+        expect(updatedCustomer).to.be.property('_embedded');
+        expect(updatedCustomer.name).to.equal(name);
+        done();
+      });
+    });
   });
 
   describe('Delete a customer', function() {
-    it('it should update a customer', function(done) {
+    it('it should delete a customer', function(done) {
       vhx.customers.create({ name: params.name(), email: params.email() }, function(err, customer) {
         vhx.customers.del(customer.id, function(err) {
           expect(err).to.equal(false);
@@ -80,7 +127,7 @@ describe('Customers', function() {
   });
 
   describe('Add a product to a customer', function() {
-    it('it should add a product a customer', function(done) {
+    it('it should add a product to a customer', function(done) {
       vhx.customers.create({ name: params.name(), email: params.email() }, function(err, customer) {
         vhx.customers.addProduct(customer.id, { product: params.product() }, function(err, updatedCustomer) {
           expect(updatedCustomer).to.be.property('_embedded');
@@ -93,7 +140,7 @@ describe('Customers', function() {
   });
 
   describe('Remove a product from a customer', function() {
-    it('it should update a customer', function(done) {
+    it('it should remove a product from a customer', function(done) {
       vhx.customers.create({ name: params.name(), email: params.email() }, function(err, customer) {
         vhx.customers.addProduct(customer.id, { product: params.product() }, function() {
           vhx.customers.removeProduct(customer.id, { product: params.product() }, function(err, updatedCustomer) {

--- a/test/products.js
+++ b/test/products.js
@@ -28,7 +28,7 @@ describe('Products', function() {
 
   describe('Retrieve a product', function() {
       it('it should GET a single product', function(done) {
-        vhx.products.retrieve(params.product(), function(err, product) {
+        vhx.products.retrieve(params.product(), { 'VHX-X-Header': 'foo' }, function(err, product) {
           expect(product).to.be.a('object');
           expect(product).to.be.property('_links');
           expect(product).to.be.property('price');

--- a/test/watching.js
+++ b/test/watching.js
@@ -15,7 +15,7 @@ describe('Watching', function() {
 
   describe('List all videos', function() {
     it('it should GET all videos being watched', function(done) {
-      vhx.watching.items(params.customer(), function(err, videos) {
+      vhx.watching.items(params.customer(), { 'VHX-X-Header': 'foo' }, function(err, videos) {
         expect(videos).to.be.a('object');
         expect(videos).to.be.property('_links');
         expect(videos).to.be.property('_embedded');

--- a/test/watchlist.js
+++ b/test/watchlist.js
@@ -30,7 +30,7 @@ describe('Watchlist', function() {
     it('it should ADD a video to customer\'s watchlist queue', function(done) {
       vhx.watchlist.addItem(params.customer(), {
         video: params.video()
-      }, function(err) {
+      }, { 'VHX-X-Header': 'foo' }, function(err) {
         expect(err).to.equal(false);
         done();
       });


### PR DESCRIPTION
Adds header support. Headers can be passed as an object via the last param (either the second or third param depending on the method).

Example:

```node
vhx.customers.create({ 
  'name': 'First Last',
  'email': 'customer@email.com',
  'product': 'https://api.vhx.tv/products/1'
}, { 'VHX-Client-IP': '0.0.0.0' }, function(err, customer) {
});
```

👀  @davegonzalez 